### PR TITLE
multi: unit test opensearch and in-memory stores

### DIFF
--- a/pkg/search/backendstore/opensearch_test.go
+++ b/pkg/search/backendstore/opensearch_test.go
@@ -1,0 +1,457 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backendstore
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go"
+	"github.com/opensearch-project/opensearch-go/opensearchapi"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	coretesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
+	testing3 "github.com/karmada-io/karmada/pkg/util/testing"
+)
+
+func TestNewOpenSearch(t *testing.T) {
+	secretName, namespace := "opensearch-credentials", "default"
+	tests := []struct {
+		name        string
+		clusterName string
+		cfg         *searchv1alpha1.BackendStoreConfig
+		prep        func() error
+		wantErr     bool
+		errMsg      string
+		logMsg      string
+	}{
+		{
+			name:        "NewOpenSearch_WithoutOpenSearchConfig_OpenSearchConfigIsNil",
+			clusterName: "member1",
+			cfg:         nil,
+			prep:        func() error { return nil },
+			wantErr:     true,
+			errMsg:      "opensearch config is nil",
+		},
+		{
+			name:        "NewOpenSearch_WithoutAddresses_OpenSearchAddressesNotFound",
+			clusterName: "member1",
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{},
+				},
+			},
+			prep:    func() error { return nil },
+			wantErr: true,
+			errMsg:  "not found opensearch address",
+		},
+		{
+			name:        "WithoutOpenSearchCredentialsSecret_SecretNotFoundUnauthorizedClient",
+			clusterName: "member1",
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+				},
+			},
+			prep: func() error {
+				OpenSearchClientBuilder = func(opensearch.Config) (*opensearch.Client, error) {
+					response := &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+					mTransport := computeMTransport(response, nil)
+					client := &opensearch.Client{Transport: mTransport}
+					client.API = opensearchapi.New(client)
+					return client, nil
+				}
+				return nil
+			},
+			wantErr: false,
+			logMsg:  "Not found secret for opensearch, try to without auth",
+		},
+		{
+			name:        "NetworkIssueWhileGettingSecrets_FailedToGetSecrets",
+			clusterName: "member1",
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			prep: func() error {
+				k8sClient = fakeclientset.NewSimpleClientset()
+				k8sClient.(*fakeclientset.Clientset).Fake.PrependReactor("get", "secrets", func(coretesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("unexpected error: encountered a network issue while getting the secrets")
+				})
+				OpenSearchClientBuilder = func(opensearch.Config) (*opensearch.Client, error) {
+					response := &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+					mTransport := computeMTransport(response, nil)
+					client := &opensearch.Client{Transport: mTransport}
+					client.API = opensearchapi.New(client)
+					return client, nil
+				}
+				return nil
+			},
+			wantErr: false,
+			logMsg:  "encountered a network issue while getting the secrets",
+		},
+		{
+			name:        "NetworkIssueWhileCreatingOpenSearchClient_FailedToCreateClient",
+			clusterName: "member1",
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			prep: func() error {
+				username, password := "opensearchuser", "opensearchpass"
+				k8sClient = fakeclientset.NewSimpleClientset()
+				if err := createOpenSearchCredentialsSecret(k8sClient, username, password, secretName, namespace); err != nil {
+					return fmt.Errorf("failed to create open search credentials secret, got: %v", err)
+				}
+				OpenSearchClientBuilder = func(opensearch.Config) (*opensearch.Client, error) {
+					return nil, errors.New("got network issue")
+				}
+				return nil
+			},
+			wantErr: true,
+			errMsg:  "cannot create opensearch client: got network issue",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.logMsg != "" {
+				r, w, oldStdErr, err := prepLogMsgWatcher()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() {
+					if err := verifyLogMsg(r, w, oldStdErr, test.logMsg); err != nil {
+						t.Error(err)
+					}
+				}()
+			}
+			if err := test.prep(); err != nil {
+				t.Fatalf("failed to prep test environment, got error: %v", err)
+			}
+			_, err := NewOpenSearch(test.clusterName, test.cfg)
+			if err == nil && test.wantErr {
+				t.Fatal("expected an error, but got none")
+			}
+			if err != nil && !test.wantErr {
+				t.Errorf("unexpected error, got: %v", err)
+			}
+			if err != nil && test.wantErr && !strings.Contains(err.Error(), test.errMsg) {
+				t.Errorf("expected error message %s to be in %s", test.errMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestGetOrCreateIndexName(t *testing.T) {
+	secretName, namespace := "opensearch-credentials", "default"
+	tests := []struct {
+		name          string
+		us            *unstructured.Unstructured
+		os            *OpenSearch
+		cfg           *searchv1alpha1.BackendStoreConfig
+		client        clientset.Interface
+		prep          func(*searchv1alpha1.BackendStoreConfig, clientset.Interface, *unstructured.Unstructured) (*OpenSearch, error)
+		wantErr       bool
+		errMsg        string
+		wantIndexName string
+	}{
+		{
+			name: "NetworkIssueInRequestErr_FailedToCreateIndex",
+			us: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, _ *unstructured.Unstructured) (*OpenSearch, error) {
+				return createOpenSearch(client, nil, errors.New("got network issue while doing the request"), secretName, namespace)
+			},
+			wantErr: true,
+			errMsg:  "got network issue while doing the request",
+		},
+		{
+			name: "NetworkIssueInResponse_FailedToCreateIndex",
+			us: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, _ *unstructured.Unstructured) (*OpenSearch, error) {
+				response := &http.Response{StatusCode: http.StatusBadGateway, Body: http.NoBody}
+				return createOpenSearch(client, computeMTransport(response, nil), nil, secretName, namespace)
+			},
+			wantErr: true,
+			errMsg:  "cannot create index: [502 Bad Gateway]",
+		},
+		{
+			name: "RequestErrorIndexExists_UpdateTheIndexInMemoryAndGetIt",
+			us: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, _ *unstructured.Unstructured) (*OpenSearch, error) {
+				return createOpenSearch(client, computeMTransport(nil, errors.New(resourceExistsError)), nil, secretName, namespace)
+			},
+			wantErr:       false,
+			wantIndexName: fmt.Sprintf("%s-deployment", defaultPrefix),
+		},
+		{
+			name: "ResponseErrorIndexExists_UpdateTheIndexInMemoryAndGetIt",
+			us: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, _ *unstructured.Unstructured) (*OpenSearch, error) {
+				response := &http.Response{StatusCode: http.StatusConflict, Body: io.NopCloser(strings.NewReader(resourceExistsError))}
+				return createOpenSearch(client, computeMTransport(response, nil), nil, secretName, namespace)
+			},
+			wantErr:       false,
+			wantIndexName: fmt.Sprintf("%s-deployment", defaultPrefix),
+		},
+		{
+			name: "IndexNotExist_CreatedThatIndex",
+			us: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, _ *unstructured.Unstructured) (*OpenSearch, error) {
+				response := &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
+				return createOpenSearch(client, computeMTransport(response, nil), nil, secretName, namespace)
+			},
+			wantErr:       false,
+			wantIndexName: fmt.Sprintf("%s-deployment", defaultPrefix),
+		},
+		{
+			name: "IndexIsAlreadyInMemory_GotThatIndex",
+			us: &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+				},
+			},
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			client: fakeclientset.NewSimpleClientset(),
+			prep: func(_ *searchv1alpha1.BackendStoreConfig, client clientset.Interface, us *unstructured.Unstructured) (*OpenSearch, error) {
+				os, err := createOpenSearch(client, computeMTransport(nil, nil), nil, secretName, namespace)
+				if err != nil {
+					return nil, err
+				}
+				indexName := fmt.Sprintf("%s-%s", defaultPrefix, strings.ToLower(us.GetKind()))
+				os.indices[indexName] = struct{}{}
+				return os, nil
+			},
+			wantErr:       false,
+			wantIndexName: fmt.Sprintf("%s-deployment", defaultPrefix),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Init(test.client)
+			os, err := test.prep(test.cfg, test.client, test.us)
+			if err != nil {
+				t.Fatalf("failed to prep test environment, got error: %v", err)
+			}
+			test.os = os
+
+			gotIndexName, err := test.os.getOrCreateIndexName(test.us)
+			if err == nil && test.wantErr {
+				t.Fatal("expecterd an error, but got none")
+			}
+			if err != nil && !test.wantErr {
+				t.Errorf("unexpected error, got: %v", err)
+			}
+			if err != nil && test.wantErr && !strings.Contains(err.Error(), test.errMsg) {
+				t.Errorf("expected error message %s to be in %s", test.errMsg, err.Error())
+			}
+			if gotIndexName != test.wantIndexName {
+				t.Errorf("expected index name to be %s, but got %s", test.wantIndexName, gotIndexName)
+			}
+		})
+	}
+}
+
+// prepLogMsgWatcher redirects os.Stderr to a pipe for capturing log messages.
+// Returns the pipe's reader and writer, the original os.Stderr, and an error.
+func prepLogMsgWatcher() (*os.File, *os.File, *os.File, error) {
+	r, w, err := watchStdErr()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to watch stdError, got: %v", err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	return r, w, oldStderr, err
+}
+
+// verifyLogMsg checks if the expected log message is in the captured stderr output.
+// Restores os.Stderr after verification and returns an error if the message is missing.
+func verifyLogMsg(r, w *os.File, oldStdErr *os.File, logMsgExpected string) error {
+	klog.Flush()
+	gotLog, err := closeAndReadStdErr(r, w)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(gotLog, logMsgExpected) {
+		return fmt.Errorf("expected log message %s to be in %s", logMsgExpected, gotLog)
+	}
+	os.Stderr = oldStdErr
+	return nil
+}
+
+// watchStdErr creates a pipe to capture os.Stderr. Returns the pipe's reader, writer, and an error.
+func watchStdErr() (*os.File, *os.File, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create pipe: %v", err)
+	}
+	return r, w, err
+}
+
+// closeAndReadStdErr closes the writer and reads from the reader to capture stderr output.
+// Returns the output as a string and an error if reading fails.
+func closeAndReadStdErr(r *os.File, w *os.File) (string, error) {
+	// Close the writer to finish the capture.
+	w.Close()
+
+	// Read the captured output from the pipe.
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to read from pipe: %v", err)
+	}
+
+	output := buf.String()
+	return output, err
+}
+
+// createOpenSearch initializes an OpenSearch client with credentials and an optional mock transport.
+// Returns the OpenSearch instance or an error if initialization fails.
+func createOpenSearch(client clientset.Interface, transport *testing3.MockOpenSearchTransport, responseError error, secretName, namespace string) (*OpenSearch, error) {
+	if err := createOpenSearchCredentialsSecret(client, "opensearchuser", "opensearchpass", secretName, namespace); err != nil {
+		return nil, fmt.Errorf("failed to create open search credentials secret, got: %v", err)
+	}
+
+	mTransport := computeMTransport(nil, responseError)
+	if transport != nil {
+		mTransport = transport
+	}
+
+	osClient, err := opensearch.NewClient(opensearch.Config{UseResponseCheckOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	osClient.Transport = mTransport
+
+	os := &OpenSearch{client: osClient, indices: make(map[string]struct{})}
+	return os, nil
+}
+
+// computeMTransport creates a mock OpenSearch transport for testing using the given response and error.
+func computeMTransport(res *http.Response, err error) *testing3.MockOpenSearchTransport {
+	mTransport := testing3.MockOpenSearchTransport{}
+	mTransport.PerformFunc = func(*http.Request) (*http.Response, error) {
+		return res, err
+	}
+	return &mTransport
+}

--- a/pkg/search/backendstore/store.go
+++ b/pkg/search/backendstore/store.go
@@ -35,11 +35,11 @@ type BackendStore interface {
 var (
 	backendLock sync.Mutex
 	backends    map[string]BackendStore
-	k8sClient   *kubernetes.Clientset
+	k8sClient   kubernetes.Interface
 )
 
 // Init init backend store manager
-func Init(cs *kubernetes.Clientset) {
+func Init(cs kubernetes.Interface) {
 	backendLock.Lock()
 	backends = make(map[string]BackendStore)
 	k8sClient = cs

--- a/pkg/search/backendstore/store_test.go
+++ b/pkg/search/backendstore/store_test.go
@@ -1,0 +1,352 @@
+/*
+Copyright 2025 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backendstore
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go"
+	"github.com/opensearch-project/opensearch-go/opensearchapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+
+	clusterv1alpha1 "github.com/karmada-io/karmada/pkg/apis/cluster/v1alpha1"
+	searchv1alpha1 "github.com/karmada-io/karmada/pkg/apis/search/v1alpha1"
+	testingutil "github.com/karmada-io/karmada/pkg/util/testing"
+)
+
+func TestInitBackendStoreManager(t *testing.T) {
+	tests := []struct {
+		name          string
+		numGoroutines int
+		client        clientset.Interface
+		wrapInit      func(client clientset.Interface, numGoroutines int) error
+	}{
+		{
+			name:   "Init_WithNoConcurrentCalls_Initialized",
+			client: fakeclientset.NewSimpleClientset(),
+			wrapInit: func(client clientset.Interface, _ int) error {
+				Init(client)
+				return nil
+			},
+		},
+		{
+			name:          "Init_WithMultipleConcurrentCalls_Initialized",
+			numGoroutines: 3,
+			client:        fakeclientset.NewSimpleClientset(),
+			wrapInit: func(client clientset.Interface, numGoroutines int) error {
+				// Use sync.WaitGroup to wait for all goroutines to finish.
+				var wg sync.WaitGroup
+
+				// Call Init concurrently from multiple goroutines.
+				for i := 0; i < numGoroutines; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						Init(client)
+					}()
+				}
+
+				// Wait for all goroutines to finish.
+				wg.Wait()
+
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.wrapInit(test.client, test.numGoroutines); err != nil {
+				t.Fatalf("failed to init backend store manager, got: %v", err)
+			}
+			if err := verifyInitBackendStoreManager(test.client); err != nil {
+				t.Errorf("failed to verify init backend store manager, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestAddBackendStore(t *testing.T) {
+	secretName, namespace := "opensearch-credentials", "default"
+	tests := []struct {
+		name           string
+		clusterName    string
+		numGoroutines  int
+		cfg            *searchv1alpha1.BackendStoreConfig
+		client         clientset.Interface
+		wrapAddBackend func(clusterName string, cfg *searchv1alpha1.BackendStoreConfig, numGoroutines int) error
+		prep           func(clientset.Interface) error
+	}{
+		{
+			name:        "DefaultBackend_DefaultBackendStoreAdded",
+			clusterName: "member1",
+			client:      fakeclientset.NewSimpleClientset(),
+			wrapAddBackend: func(clusterName string, cfg *searchv1alpha1.BackendStoreConfig, _ int) error {
+				AddBackend(clusterName, cfg)
+				return nil
+			},
+			prep: func(clientset.Interface) error { return nil },
+		},
+		{
+			name:          "OpenSearchBackend_OpenSearchBackendStoreAdded",
+			clusterName:   "member1",
+			client:        fakeclientset.NewSimpleClientset(),
+			numGoroutines: 3,
+			cfg: &searchv1alpha1.BackendStoreConfig{
+				OpenSearch: &searchv1alpha1.OpenSearchConfig{
+					Addresses: []string{"https://10.0.0.1:9200"},
+					SecretRef: clusterv1alpha1.LocalSecretReference{
+						Name:      secretName,
+						Namespace: namespace,
+					},
+				},
+			},
+			wrapAddBackend: func(clusterName string, cfg *searchv1alpha1.BackendStoreConfig, numGoroutines int) error {
+				// Use sync.WaitGroup to wait for all goroutines to finish.
+				var wg sync.WaitGroup
+
+				// Call Init concurrently from multiple goroutines.
+				for i := 0; i < numGoroutines; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						AddBackend(clusterName, cfg)
+					}()
+				}
+
+				// Wait for all goroutines to finish.
+				wg.Wait()
+
+				return nil
+			},
+			prep: func(client clientset.Interface) error {
+				username, password := "opensearchuser", "opensearchpass"
+				if err := createOpenSearchCredentialsSecret(client, username, password, secretName, namespace); err != nil {
+					return fmt.Errorf("failed to create open search credentials secret, got: %v", err)
+				}
+				OpenSearchClientBuilder = func(opensearch.Config) (*opensearch.Client, error) {
+					mTransport := &testingutil.MockOpenSearchTransport{}
+					mTransport.PerformFunc = func(*http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       http.NoBody,
+						}, nil
+					}
+					client := &opensearch.Client{Transport: mTransport}
+					client.API = opensearchapi.New(client)
+					return client, nil
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Init(test.client)
+			if err := test.prep(test.client); err != nil {
+				t.Fatalf("failed to prep test environment before verifying adding the backend store, got: %v", err)
+			}
+			if err := test.wrapAddBackend(test.clusterName, test.cfg, test.numGoroutines); err != nil {
+				t.Fatalf("failed to add backend, got error: %v", err)
+			}
+			if err := verifyBackendStoreAdded(test.clusterName); err != nil {
+				t.Errorf("failed to verify adding the backend store, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeleteBackendStore(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		client      clientset.Interface
+		prep        func(clusterName string) error
+	}{
+		{
+			name:        "Existent_BackendStoreDeleted",
+			clusterName: "member1",
+			client:      fakeclientset.NewSimpleClientset(),
+			prep: func(clusterName string) error {
+				AddBackend(clusterName, nil)
+				return nil
+			},
+		},
+		{
+			name:        "NonExistent_NoError",
+			clusterName: "nonexistent",
+			client:      fakeclientset.NewSimpleClientset(),
+			prep:        func(string) error { return nil },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Init(test.client)
+			if err := test.prep(test.clusterName); err != nil {
+				t.Fatalf("failed to prep test environment before deleting backend store, got: %v", err)
+			}
+			DeleteBackend(test.clusterName)
+			if err := verifyBackendStoreDeleted(test.clusterName); err != nil {
+				t.Errorf("failed to verify backend store deleted for cluster name %s, got: %v", test.clusterName, err)
+			}
+		})
+	}
+}
+
+func TestGetBackendStore(t *testing.T) {
+	tests := []struct {
+		name             string
+		clusterName      string
+		client           clientset.Interface
+		numGoroutines    int
+		wrapGetBackend   func(clusterName string, numGoroutines int) BackendStore
+		prep             func(clusterName string) error
+		want             BackendStore
+		wantBackendStore bool
+	}{
+		{
+			name:        "ExistentBackendStore_BackendStoreRetrieved",
+			clusterName: "member1",
+			client:      fakeclientset.NewSimpleClientset(),
+			wrapGetBackend: func(clusterName string, _ int) BackendStore {
+				return GetBackend(clusterName)
+			},
+			prep: func(clusterName string) error {
+				AddBackend(clusterName, nil)
+				return nil
+			},
+			wantBackendStore: true,
+		},
+		{
+			name:          "ExistentWithMultipleConcurrentCalls_BackendStoreRetrieved",
+			clusterName:   "member1",
+			client:        fakeclientset.NewSimpleClientset(),
+			numGoroutines: 3,
+			wrapGetBackend: func(clusterName string, numGoroutines int) BackendStore {
+				// Use sync.WaitGroup to wait for all goroutines to finish.
+				var wg sync.WaitGroup
+
+				// Call Init concurrently from multiple goroutines.
+				for i := 0; i < numGoroutines; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						_ = GetBackend(clusterName)
+					}()
+				}
+
+				// Wait for all goroutines to finish.
+				wg.Wait()
+
+				return GetBackend(clusterName)
+			},
+			prep: func(clusterName string) error {
+				AddBackend(clusterName, nil)
+				return nil
+			},
+			wantBackendStore: true,
+		},
+		{
+			name:        "NonExistent_NoError",
+			clusterName: "nonexistent",
+			client:      fakeclientset.NewSimpleClientset(),
+			wrapGetBackend: func(clusterName string, _ int) BackendStore {
+				return GetBackend(clusterName)
+			},
+			prep:             func(string) error { return nil },
+			wantBackendStore: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Init(test.client)
+			if err := test.prep(test.clusterName); err != nil {
+				t.Fatalf("failed to prep test environment before getting backend store, got: %v", err)
+			}
+			bc := test.wrapGetBackend(test.clusterName, test.numGoroutines)
+			if bc == nil && test.wantBackendStore {
+				t.Error("expected backend store, but got none")
+			}
+			if bc != nil && !test.wantBackendStore {
+				t.Errorf("unexpected backend store retrieved, got: %v", bc)
+			}
+		})
+	}
+}
+
+func verifyInitBackendStoreManager(client clientset.Interface) error {
+	if backends == nil {
+		return fmt.Errorf("expected backends to be initialized, but got %v", backends)
+	}
+	if len(backends) != 0 {
+		return fmt.Errorf("expected backends to be empty, but got %d backends", len(backends))
+	}
+	if !reflect.DeepEqual(client, k8sClient) {
+		return fmt.Errorf("expected k8s client global varible to be %v, but got %v", client, k8sClient)
+	}
+	return nil
+}
+
+func verifyBackendStoreAdded(clusterName string) error {
+	_, ok := backends[clusterName]
+	if !ok {
+		return fmt.Errorf("expected cluster name %s to be in the backend store", clusterName)
+	}
+	return nil
+}
+
+func verifyBackendStoreDeleted(clusterName string) error {
+	_, ok := backends[clusterName]
+	if ok {
+		return fmt.Errorf("expected backend store for cluster %s to be deleted, but it still exists", clusterName)
+	}
+	return nil
+}
+
+func createOpenSearchCredentialsSecret(client clientset.Interface, username, password, secretName, namespace string) error {
+	userNameEncoded := base64.StdEncoding.EncodeToString([]byte(username))
+	passwordEncoded := base64.StdEncoding.EncodeToString([]byte(password))
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"username": []byte(userNameEncoded),
+			"password": []byte(passwordEncoded),
+		},
+	}
+	if _, err := client.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create secret %s in namespace %s, got error: %v", secretName, namespace, err)
+	}
+	return nil
+}

--- a/pkg/util/testing/mock_opensearch.go
+++ b/pkg/util/testing/mock_opensearch.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 The Karmada Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import "net/http"
+
+// MockOpenSearchTransport is a mock implementation of opensearchtransport.Interface for testing purposes.
+type MockOpenSearchTransport struct {
+	PerformFunc func(req *http.Request) (*http.Response, error)
+}
+
+// Perform executes the mock PerformFunc if it has been defined (is not nil).
+// If PerformFunc is undefined (nil), this method will panic, signaling that
+// a mock implementation for Perform has not been provided for this test.
+func (m *MockOpenSearchTransport) Perform(req *http.Request) (*http.Response, error) {
+	if m.PerformFunc != nil {
+		return m.PerformFunc(req)
+	}
+	panic("perform is not implemented")
+}


### PR DESCRIPTION
In this commit, we unit test opensearch and in-memory stores for karmada search aggregated apiserver as cache registry on creating new instance and getting/creating an index.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind feature
/kind documentation
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #

<!--
*Optionally link to the umbrella issue if this PR resolves part of it.
Usage: `Part of #<issue number>`, or `Part of (paste link of issue)`.*
Part of #
-->

**Special notes for your reviewer**:
<!--
Such as a test report of this PR.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
Some brief examples of release notes:
1. `karmada-controller-manager`: Fixed the issue that xxx
2. `karmada-scheduler`: The deprecated flag `--xxx` now has been removed. Users of this flag should xxx.
3. `API Change`: Introduced `spec.<field>` to the PropagationPolicy API for xxx.
-->
```release-note

```

